### PR TITLE
Fix default CURSOR_DARK value

### DIFF
--- a/knightadjuster
+++ b/knightadjuster
@@ -6,7 +6,7 @@ THRESHOLD_DARK=4800
 
 PLASMA_DARK=BreezeDark
 PLASMA_LIGHT=BreezeClassic
-CURSOR_DARK=Breeze_Light
+CURSOR_DARK=Breeze_Snow
 CURSOR_LIGHT=breeze_cursors
 ICON_DARK=breeze-dark
 ICON_LIGHT=breeze


### PR DESCRIPTION
Breeze's light cursor theme is called Breeze_Snow, not Breeze_Dark (at least on My Machine).